### PR TITLE
Some changes to achieve compatibility with php8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.0",
+        "php": "^7.1.0 || ^8.0",
         "ext-json": "*",
         "php-http/discovery": "^1.0.0",
         "php-http/httplug": "^2.0.0",
@@ -30,9 +30,9 @@
     },
     "require-dev": {
         "nyholm/psr7": "^1.0.0",
-        "phpunit/phpunit": "^7.0.0",
-        "php-http/mock-client": "dev-upgrade-version-2",
-        "phpstan/phpstan": "^0.12.2",
+        "phpunit/phpunit": "^8.0.0",
+        "php-http/mock-client": ">= 1.4.1",
+        "phpstan/phpstan": ">= 0.1",
         "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload": {
@@ -44,6 +44,9 @@
         "psr-4": {
             "Dhl\\Sdk\\Paket\\Retoure\\Test\\": "test/"
         }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyze -c phpstan.neon --memory-limit=2G"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     },
     "require-dev": {
         "nyholm/psr7": "^1.0.0",
-        "phpunit/phpunit": "^8.0.0",
-        "php-http/mock-client": ">= 1.4.1",
+        "phpunit/phpunit": ">= 7.0 < 9.0",
+        "rkr/php-http-mock-client-psr-provider": "^0.1.0",
         "phpstan/phpstan": ">= 0.1",
         "squizlabs/php_codesniffer": "^3.4"
     },
@@ -46,6 +46,7 @@
         }
     },
     "scripts": {
+        "phpunit": "phpunit -c test/phpunit.xml",
         "phpstan": "phpstan analyze -c phpstan.neon --memory-limit=2G"
     },
     "extra": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,5 @@
-includes:
 parameters:
+    level: max
+    paths:
+        - src
+        - test

--- a/test/Expectation/ReturnLabelServiceTestExpectation.php
+++ b/test/Expectation/ReturnLabelServiceTestExpectation.php
@@ -28,9 +28,9 @@ class ReturnLabelServiceTestExpectation
      * @param ReturnOrder $returnOrder The request object ready for serialization.
      * @param string $requestJson The actual message sent to the web service.
      */
-    public static function assertLabelRequest(ReturnOrder $returnOrder, string $requestJson)
+    public static function assertLabelRequest(ReturnOrder $returnOrder, string $requestJson): void
     {
-        $expected = json_decode(json_encode($returnOrder), true);
+        $expected = json_decode((string) json_encode($returnOrder), true);
         $actual = json_decode($requestJson, true);
 
         Assert::assertSame($expected['receiverId'], $actual['receiverId']);
@@ -65,7 +65,7 @@ class ReturnLabelServiceTestExpectation
      * @param ConfirmationInterface $result
      * @param string $responseJson
      */
-    public static function assertLabelResponse(ConfirmationInterface $result, string $responseJson)
+    public static function assertLabelResponse(ConfirmationInterface $result, string $responseJson): void
     {
         $responseData = json_decode($responseJson, true);
 
@@ -86,7 +86,7 @@ class ReturnLabelServiceTestExpectation
      * @return void
      * @throws ExpectationFailedException
      */
-    public static function assertErrorLogged(TestLogger $logger, string $responseBody = '')
+    public static function assertErrorLogged(TestLogger $logger, string $responseBody = ''): void
     {
         Assert::assertTrue($logger->hasErrorRecords(), 'No error logged.');
 
@@ -109,7 +109,7 @@ class ReturnLabelServiceTestExpectation
      * @return void
      * @throws ExpectationFailedException
      */
-    public static function assertCommunicationLogged(TestLogger $logger, string $requestBody, string $responseJson = '')
+    public static function assertCommunicationLogged(TestLogger $logger, string $requestBody, string $responseJson = ''): void
     {
         Assert::assertTrue($logger->hasInfoRecords(), 'Logger has no info messages');
 

--- a/test/Provider/ReturnLabelRequestProvider.php
+++ b/test/Provider/ReturnLabelRequestProvider.php
@@ -10,6 +10,7 @@ namespace Dhl\Sdk\Paket\Retoure\Test\Provider;
 
 use Dhl\Sdk\Paket\Retoure\Exception\RequestValidatorException;
 use Dhl\Sdk\Paket\Retoure\Model\ReturnLabelRequestBuilder;
+use JsonSerializable;
 
 /**
  * Class ReturnLabelRequestProvider
@@ -23,10 +24,10 @@ class ReturnLabelRequestProvider
      * Build a valid request for a domestic return label. Configurable return document type.
      *
      * @param string|null $qrCode
-     * @return \JsonSerializable
+     * @return JsonSerializable
      * @throws RequestValidatorException
      */
-    public static function validRequest(string $qrCode = null): \JsonSerializable
+    public static function validRequest(string $qrCode = null): JsonSerializable
     {
         $requestBuilder = new ReturnLabelRequestBuilder();
         $requestBuilder->setAccountDetails('DE', '22222222220701');
@@ -54,10 +55,10 @@ class ReturnLabelRequestProvider
     /**
      * Build a valid request for a return label which requires a customs document.
      *
-     * @return \JsonSerializable
+     * @return JsonSerializable
      * @throws RequestValidatorException
      */
-    public static function validCustomsRequest(): \JsonSerializable
+    public static function validCustomsRequest(): JsonSerializable
     {
         $requestBuilder = new ReturnLabelRequestBuilder();
         $requestBuilder->setAccountDetails('CH', '22222222225301');
@@ -97,10 +98,10 @@ class ReturnLabelRequestProvider
     /**
      * Set an invalid country code as origin country to trigger a validation error response (400 Bad Request).
      *
-     * @return \JsonSerializable
+     * @return JsonSerializable
      * @throws RequestValidatorException
      */
-    public static function validationErrorRequest(): \JsonSerializable
+    public static function validationErrorRequest(): JsonSerializable
     {
         $requestBuilder = new ReturnLabelRequestBuilder();
         $requestBuilder->setAccountDetails('CH', '22222222225301');

--- a/test/Provider/ReturnLabelResponseProvider.php
+++ b/test/Provider/ReturnLabelResponseProvider.php
@@ -21,7 +21,7 @@ class ReturnLabelResponseProvider
      */
     public static function successResponse(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/labelResponse.json') ?: '';
+        return file_get_contents(__DIR__ . '/_files/labelResponse.json') ?: '';
     }
 
     /**
@@ -29,7 +29,7 @@ class ReturnLabelResponseProvider
      */
     public static function pdfResponse(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/labelResponsePdf.json') ?: '';
+        return file_get_contents(__DIR__ . '/_files/labelResponsePdf.json') ?: '';
     }
 
     /**
@@ -37,7 +37,7 @@ class ReturnLabelResponseProvider
      */
     public static function qrResponse(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/labelResponseQr.json') ?: '';
+        return file_get_contents(__DIR__ . '/_files/labelResponseQr.json') ?: '';
     }
 
     /**
@@ -45,7 +45,7 @@ class ReturnLabelResponseProvider
      */
     public static function unauthorized(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/unauthorized.html') ?: '';
+        return file_get_contents(__DIR__ . '/_files/unauthorized.html') ?: '';
     }
 
     /**
@@ -53,7 +53,7 @@ class ReturnLabelResponseProvider
      */
     public static function authenticationFailed(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/authenticationFailed.json') ?: '';
+        return file_get_contents(__DIR__ . '/_files/authenticationFailed.json') ?: '';
     }
 
     /**
@@ -61,7 +61,7 @@ class ReturnLabelResponseProvider
      */
     public static function forbidden(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/forbidden.html') ?: '';
+        return file_get_contents(__DIR__ . '/_files/forbidden.html') ?: '';
     }
 
     /**
@@ -69,7 +69,7 @@ class ReturnLabelResponseProvider
      */
     public static function validationFailed(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/validationFailed.json') ?: '';
+        return file_get_contents(__DIR__ . '/_files/validationFailed.json') ?: '';
     }
 
     /**
@@ -77,7 +77,7 @@ class ReturnLabelResponseProvider
      */
     public static function serverError(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/serverError.json') ?: '';
+        return file_get_contents(__DIR__ . '/_files/serverError.json') ?: '';
     }
 
     /**
@@ -85,6 +85,6 @@ class ReturnLabelResponseProvider
      */
     public static function serverErrorHtml(): string
     {
-        return \file_get_contents(__DIR__ . '/_files/serverError.html') ?: '';
+        return file_get_contents(__DIR__ . '/_files/serverError.html') ?: '';
     }
 }

--- a/test/Provider/ReturnLabelServiceTestProvider.php
+++ b/test/Provider/ReturnLabelServiceTestProvider.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Dhl\Sdk\Paket\Retoure\Test\Provider;
 
 use Dhl\Sdk\Paket\Retoure\Exception\RequestValidatorException;
+use JsonSerializable;
 
 /**
  * Class ReturnLabelServiceTestProvider
@@ -19,7 +20,7 @@ use Dhl\Sdk\Paket\Retoure\Exception\RequestValidatorException;
 class ReturnLabelServiceTestProvider
 {
     /**
-     * @return \JsonSerializable[][]|string[][]
+     * @return JsonSerializable[][]|string[][]
      * @throws RequestValidatorException
      */
     public static function labelSuccess(): array
@@ -42,7 +43,7 @@ class ReturnLabelServiceTestProvider
     }
 
     /**
-     * @return \JsonSerializable[][]|int[][]|string[][]
+     * @return JsonSerializable[][]|int[][]|string[][]
      * @throws RequestValidatorException
      */
     public static function labelError(): array
@@ -71,7 +72,7 @@ class ReturnLabelServiceTestProvider
     }
 
     /**
-     * @return \JsonSerializable[][]
+     * @return JsonSerializable[][]
      * @throws RequestValidatorException
      */
     public static function networkError(): array

--- a/test/TestCase/ReturnLabelRequestBuilderTest.php
+++ b/test/TestCase/ReturnLabelRequestBuilderTest.php
@@ -112,23 +112,23 @@ class ReturnLabelRequestBuilderTest extends TestCase
         $builder->addCustomsItem(5, 'DHL Foo', 59, 800, '24-MB05', 'DEU', '123456');
 
         $request = $builder->create();
-        $requestJson = json_encode($request, JSON_UNESCAPED_UNICODE);
+        $requestJson = (string) json_encode($request, JSON_UNESCAPED_UNICODE);
 
-        self::assertContains("\"receiverId\":\"{$receiverId}\"", $requestJson);
-        self::assertContains("\"customerReference\":\"{$billingNumber}\"", $requestJson);
-        self::assertContains("\"shipmentReference\":\"{$shipmentReference}\"", $requestJson);
-        self::assertContains("\"returnDocumentType\":\"SHIPMENT_LABEL\"", $requestJson);
-        self::assertContains("\"email\":\"{$email}\"", $requestJson);
-        self::assertContains("\"telephoneNumber\":\"{$phone}\"", $requestJson);
-        self::assertContains("\"name1\":\"{$shipperName}\"", $requestJson);
-        self::assertContains("\"countryISOCode\":\"{$shipperCountry}\"", $requestJson);
-        self::assertContains("\"postCode\":\"{$shipperPostalCode}\"", $requestJson);
-        self::assertContains("\"city\":\"{$shipperCity}\"", $requestJson);
-        self::assertContains("\"streetName\":\"{$shipperStreetName}\"", $requestJson);
-        self::assertContains("\"houseNumber\":\"{$shipperStreetNumber}\"", $requestJson);
-        self::assertContains("\"weightInGrams\":{$weight}", $requestJson);
-        self::assertContains("\"value\":{$amount}", $requestJson);
-        self::assertContains("\"currency\":\"{$currency}\"", $requestJson);
+        self::assertStringContainsString("\"receiverId\":\"{$receiverId}\"", $requestJson);
+        self::assertStringContainsString("\"customerReference\":\"{$billingNumber}\"", $requestJson);
+        self::assertStringContainsString("\"shipmentReference\":\"{$shipmentReference}\"", $requestJson);
+        self::assertStringContainsString("\"returnDocumentType\":\"SHIPMENT_LABEL\"", $requestJson);
+        self::assertStringContainsString("\"email\":\"{$email}\"", $requestJson);
+        self::assertStringContainsString("\"telephoneNumber\":\"{$phone}\"", $requestJson);
+        self::assertStringContainsString("\"name1\":\"{$shipperName}\"", $requestJson);
+        self::assertStringContainsString("\"countryISOCode\":\"{$shipperCountry}\"", $requestJson);
+        self::assertStringContainsString("\"postCode\":\"{$shipperPostalCode}\"", $requestJson);
+        self::assertStringContainsString("\"city\":\"{$shipperCity}\"", $requestJson);
+        self::assertStringContainsString("\"streetName\":\"{$shipperStreetName}\"", $requestJson);
+        self::assertStringContainsString("\"houseNumber\":\"{$shipperStreetNumber}\"", $requestJson);
+        self::assertStringContainsString("\"weightInGrams\":{$weight}", $requestJson);
+        self::assertStringContainsString("\"value\":{$amount}", $requestJson);
+        self::assertStringContainsString("\"currency\":\"{$currency}\"", $requestJson);
     }
 
     /**

--- a/test/TestCase/ReturnLabelRequestBuilderTest.php
+++ b/test/TestCase/ReturnLabelRequestBuilderTest.php
@@ -10,6 +10,7 @@ namespace Dhl\Sdk\Paket\Retoure\Model;
 
 use Dhl\Sdk\Paket\Retoure\Exception\RequestValidatorException;
 use Dhl\Sdk\Paket\Retoure\Model\ReturnLabelRequestValidator as Validator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ReturnLabelRequestValidatorTest
@@ -17,10 +18,10 @@ use Dhl\Sdk\Paket\Retoure\Model\ReturnLabelRequestValidator as Validator;
  * @author Andreas Müller <andreas.mueller@netresearch.de>
  * @link   https://www.netresearch.de/
  */
-class ReturnLabelRequestBuilderTest extends \PHPUnit\Framework\TestCase
+class ReturnLabelRequestBuilderTest extends TestCase
 {
     /**
-     * @return ReturnLabelRequestBuilder[][]
+     * @return array<string, array{ReturnLabelRequestBuilder, string}>
      */
     public function dataProvider(): array
     {
@@ -87,7 +88,7 @@ class ReturnLabelRequestBuilderTest extends \PHPUnit\Framework\TestCase
      * @test
      * @throws RequestValidatorException
      */
-    public function validRequest()
+    public function validRequest(): void
     {
         $builder = new ReturnLabelRequestBuilder();
         $builder->setAccountDetails($receiverId = 'CH', $billingNumber = '22222222225301');
@@ -139,12 +140,12 @@ class ReturnLabelRequestBuilderTest extends \PHPUnit\Framework\TestCase
      * @param string $exceptionMessage
      * @throws RequestValidatorException
      */
-    public function invalidRequest(ReturnLabelRequestBuilder $builder, string $exceptionMessage)
+    public function invalidRequest(ReturnLabelRequestBuilder $builder, string $exceptionMessage): void
     {
         $this->expectException(RequestValidatorException::class);
         if (strpos($exceptionMessage, '%s') !== false) {
             $exceptionMessage = str_replace('%s', '[\w]+', $exceptionMessage);
-            $this->expectExceptionMessageRegExp("/$exceptionMessage/");
+            $this->expectExceptionMessageMatches("/$exceptionMessage/");
         } else {
             $this->expectExceptionMessage($exceptionMessage);
         }

--- a/test/TestCase/ReturnLabelRequestBuilderTest.php
+++ b/test/TestCase/ReturnLabelRequestBuilderTest.php
@@ -11,6 +11,7 @@ namespace Dhl\Sdk\Paket\Retoure\Model;
 use Dhl\Sdk\Paket\Retoure\Exception\RequestValidatorException;
 use Dhl\Sdk\Paket\Retoure\Model\ReturnLabelRequestValidator as Validator;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 
 /**
  * Class ReturnLabelRequestValidatorTest
@@ -145,7 +146,11 @@ class ReturnLabelRequestBuilderTest extends TestCase
         $this->expectException(RequestValidatorException::class);
         if (strpos($exceptionMessage, '%s') !== false) {
             $exceptionMessage = str_replace('%s', '[\w]+', $exceptionMessage);
-            $this->expectExceptionMessageMatches("/$exceptionMessage/");
+			if(version_compare(Version::id(), '8.0', '>=')) {
+				$this->expectExceptionMessageMatches("/$exceptionMessage/");
+			} else {
+				$this->expectExceptionMessageRegExp("/$exceptionMessage/");
+			}
         } else {
             $this->expectExceptionMessage($exceptionMessage);
         }

--- a/test/TestCase/ReturnLabelServiceTest.php
+++ b/test/TestCase/ReturnLabelServiceTest.php
@@ -65,7 +65,7 @@ class ReturnLabelServiceTest extends TestCase
      * @test
      * @dataProvider successDataProvider
      *
-     * @param JsonSerializable|ReturnOrder $returnOrder
+     * @param ReturnOrder $returnOrder
      * @param string $responseBody
      * @throws ServiceException
      */

--- a/test/TestCase/ReturnLabelServiceTest.php
+++ b/test/TestCase/ReturnLabelServiceTest.php
@@ -20,6 +20,7 @@ use Dhl\Sdk\Paket\Retoure\Test\Provider\ReturnLabelServiceTestProvider;
 use Http\Client\Exception\NetworkException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Mock\Client;
+use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
 
@@ -32,7 +33,7 @@ use Psr\Log\Test\TestLogger;
 class ReturnLabelServiceTest extends TestCase
 {
     /**
-     * @return \JsonSerializable[][]|string[][]
+     * @return JsonSerializable[][]|string[][]
      * @throws RequestValidatorException
      */
     public function successDataProvider(): array
@@ -41,7 +42,7 @@ class ReturnLabelServiceTest extends TestCase
     }
 
     /**
-     * @return \JsonSerializable[][]|int[][]|string[][]
+     * @return JsonSerializable[][]|int[][]|string[][]
      * @throws RequestValidatorException
      */
     public function errorDataProvider(): array
@@ -50,7 +51,7 @@ class ReturnLabelServiceTest extends TestCase
     }
 
     /**
-     * @return \JsonSerializable[][]
+     * @return JsonSerializable[][]
      * @throws RequestValidatorException
      */
     public function networkErrorDataProvider(): array
@@ -64,11 +65,11 @@ class ReturnLabelServiceTest extends TestCase
      * @test
      * @dataProvider successDataProvider
      *
-     * @param \JsonSerializable|ReturnOrder $returnOrder
+     * @param JsonSerializable|ReturnOrder $returnOrder
      * @param string $responseBody
      * @throws ServiceException
      */
-    public function bookLabelSuccess(ReturnOrder $returnOrder, string $responseBody)
+    public function bookLabelSuccess(ReturnOrder $returnOrder, string $responseBody): void
     {
         $httpClient = new Client();
 
@@ -97,7 +98,7 @@ class ReturnLabelServiceTest extends TestCase
      * @test
      * @dataProvider errorDataProvider
      *
-     * @param \JsonSerializable $returnOrder
+     * @param JsonSerializable $returnOrder
      * @param int $statusCode
      * @param string $contentType
      * @param string $responseBody
@@ -105,16 +106,16 @@ class ReturnLabelServiceTest extends TestCase
      * @throws ServiceException
      */
     public function returnLabelError(
-        \JsonSerializable $returnOrder,
+        JsonSerializable $returnOrder,
         int $statusCode,
         string $contentType,
         string $responseBody
-    ) {
+    ): void {
         $this->expectExceptionCode($statusCode);
 
         if ($statusCode === 401) {
             $this->expectException(AuthenticationException::class);
-            $this->expectExceptionMessageRegExp('/^Authentication failed\./');
+            $this->expectExceptionMessageMatches('/^Authentication failed\./');
         } elseif (($statusCode >= 400) && ($statusCode < 500)) {
             if ($contentType === 'application/json') {
                 $this->expectException(DetailedServiceException::class);
@@ -157,10 +158,10 @@ class ReturnLabelServiceTest extends TestCase
      *
      * @test
      * @dataProvider networkErrorDataProvider
-     * @param \JsonSerializable $returnOrder
+     * @param JsonSerializable $returnOrder
      * @throws ServiceException
      */
-    public function networkError(\JsonSerializable $returnOrder)
+    public function networkError(JsonSerializable $returnOrder): void
     {
         $this->expectException(ServiceException::class);
 

--- a/test/TestCase/ReturnLabelServiceTest.php
+++ b/test/TestCase/ReturnLabelServiceTest.php
@@ -22,6 +22,7 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Mock\Client;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 use Psr\Log\Test\TestLogger;
 
 /**
@@ -115,7 +116,11 @@ class ReturnLabelServiceTest extends TestCase
 
         if ($statusCode === 401) {
             $this->expectException(AuthenticationException::class);
-            $this->expectExceptionMessageMatches('/^Authentication failed\./');
+			if(version_compare(Version::id(), '8.0', '>=')) {
+				$this->expectExceptionMessageMatches('/^Authentication failed\./');
+			} else {
+				$this->expectExceptionMessageRegExp('/^Authentication failed\./');
+			}
         } elseif (($statusCode >= 400) && ($statusCode < 500)) {
             if ($contentType === 'application/json') {
                 $this->expectException(DetailedServiceException::class);

--- a/test/TestCase/ReturnLabelServiceTest.php
+++ b/test/TestCase/ReturnLabelServiceTest.php
@@ -167,7 +167,7 @@ class ReturnLabelServiceTest extends TestCase
 
         $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
         $requestFactory = Psr17FactoryDiscovery::findRequestFactory();
-        $payload = json_encode($returnOrder);
+        $payload = (string) json_encode($returnOrder);
         $stream = $streamFactory->createStream($payload);
 
         $httpClient = new Client();


### PR DESCRIPTION
- Fixed some issues reported by phpstan (missing return types)
- Composer: Raised phpunit to ^8.0
- Composer: php-http/mock-client is now regularly provided in the latest version. Min = 1.4.1, which is compatible from 7.1 up to 8.0
- Composer: phpstan is now regularly provided in the latest version
- Composer: Added script section for phpstan
- Added meaningful phpstan.neon