### PR TITLE
psr update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/http-factory-implementation": "^1.0.0",
         "psr/http-message": "^1.0.0",
         "psr/http-message-implementation": "^1.0.0",
-        "psr/log": "^1.1.0"
+        "psr/log": "^1.1.0 | ^2 | ^3"
     },
     "require-dev": {
         "nyholm/psr7": "^1.0.0",

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -14,7 +14,7 @@ use Dhl\Sdk\Paket\Retoure\Api\ServiceFactoryInterface;
 use Dhl\Sdk\Paket\Retoure\Exception\ServiceExceptionFactory;
 use Dhl\Sdk\Paket\Retoure\Http\HttpServiceFactory;
 use Http\Discovery\Exception\NotFoundException;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Log\LoggerInterface;
 
 class ServiceFactory implements ServiceFactoryInterface
@@ -25,7 +25,7 @@ class ServiceFactory implements ServiceFactoryInterface
         bool $sandboxMode = false
     ): ReturnLabelServiceInterface {
         try {
-            $httpClient = HttpClientDiscovery::find();
+            $httpClient = Psr18ClientDiscovery::find();
         } catch (NotFoundException $exception) {
             throw ServiceExceptionFactory::create($exception);
         }


### PR DESCRIPTION
These are the same changes as in https://github.com/netresearch/dhl-sdk-api-bcs/pull/11

The psr standards have progressed and the logging interface now contains typing information.
Since this is not implemented but just used here, there is no harm in allowing newer version.

There is also the issue of the `HttpClientDiscovery` class, which is deprecated and searches for the depcrecated `HttpClient` interface that no modern http client implements. The `HttpServiceFactory` was already hinting to the more modern `ClientInterface` so using the more modern `Psr18ClientDiscovery` should bring no harm and the `HttpClient` interface extends the `ClientInterface` so there should be no compatibility issue.